### PR TITLE
WhisperKitApi update

### DIFF
--- a/packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart
+++ b/packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart
@@ -33,8 +33,8 @@ class FlutterWhisperKit {
   /// - [onProgress]: A callback function that receives download progress updates.
   ///   This can be used to display a progress indicator to the user.
   ///
-  /// Returns a [Future] that completes with a success message when the model
-  /// is loaded successfully, or throws a [WhisperKitError] if loading fails.
+  /// Returns the path to the model folder if the model is loaded successfully,
+  /// or throws a [WhisperKitError] if loading fails.
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,

--- a/packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart
+++ b/packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart
@@ -32,8 +32,6 @@ class FlutterWhisperKit {
   ///   Set to true to ensure you have the latest version of the model.
   /// - [onProgress]: A callback function that receives download progress updates.
   ///   This can be used to display a progress indicator to the user.
-  /// - [modelDownloadPath]: Custom path where the model should be downloaded.
-  ///   If not provided, the model will be stored in the default location.
   ///
   /// Returns a [Future] that completes with a success message when the model
   /// is loaded successfully, or throws a [WhisperKitError] if loading fails.
@@ -42,7 +40,6 @@ class FlutterWhisperKit {
     String? modelRepo,
     bool redownload = false,
     Function(Progress progress)? onProgress,
-    String? modelDownloadPath,
   }) async {
     // Subscribe to the progress stream if a callback is provided
     StreamSubscription<Progress>? progressSubscription;
@@ -63,7 +60,6 @@ class FlutterWhisperKit {
         variant,
         modelRepo: modelRepo,
         redownload: redownload,
-        modelDownloadPath: modelDownloadPath,
         hasProgressCallback: onProgress != null,
       );
     } on PlatformException catch (e) {

--- a/packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart
+++ b/packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart
@@ -40,7 +40,7 @@ class FlutterWhisperKit {
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,
-    bool? redownload,
+    bool redownload = false,
     Function(Progress progress)? onProgress,
     String? modelDownloadPath,
   }) async {

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart
@@ -123,7 +123,6 @@ class MethodChannelFlutterWhisperKit extends FlutterWhisperKitPlatform {
   /// - [variant]: The model variant to load (e.g., 'tiny-en', 'base', 'small', 'medium', 'large-v2').
   /// - [modelRepo]: The repository to download the model from.
   /// - [redownload]: Whether to force redownload the model even if it exists locally.
-  /// - [modelDownloadPath]: Custom path where the model should be downloaded.
   /// - [hasProgressCallback]: Whether to provide a progress callback.
   ///   If true, the progress callback will be provided to the native code.
   ///
@@ -134,14 +133,12 @@ class MethodChannelFlutterWhisperKit extends FlutterWhisperKitPlatform {
     String? variant, {
     String? modelRepo,
     bool redownload = false,
-    String? modelDownloadPath,
     bool hasProgressCallback = false,
   }) async {
     return _whisperKitMessage.loadModel(
       variant,
       modelRepo,
       redownload,
-      modelDownloadPath,
       hasProgressCallback,
     );
   }

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart
@@ -133,7 +133,7 @@ class MethodChannelFlutterWhisperKit extends FlutterWhisperKitPlatform {
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,
-    bool? redownload,
+    bool redownload = false,
     String? modelDownloadPath,
     bool hasProgressCallback = false,
   }) async {

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart
@@ -126,8 +126,8 @@ class MethodChannelFlutterWhisperKit extends FlutterWhisperKitPlatform {
   /// - [hasProgressCallback]: Whether to provide a progress callback.
   ///   If true, the progress callback will be provided to the native code.
   ///
-  /// Returns a [Future] that completes with a success message when the model
-  /// is loaded successfully, or an error message if loading fails.
+  /// Returns the path to the model folder if the model is loaded successfully,
+  /// or an error message if loading fails.
   @override
   Future<String?> loadModel(
     String? variant, {

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart
@@ -74,7 +74,7 @@ abstract class FlutterWhisperKitPlatform extends PlatformInterface {
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,
-    bool? redownload,
+    bool redownload = false,
     String? modelDownloadPath,
     bool hasProgressCallback = false,
   }) {

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart
@@ -65,10 +65,8 @@ abstract class FlutterWhisperKitPlatform extends PlatformInterface {
   /// - [hasProgressCallback]: Whether to provide a progress callback.
   ///   If true, the progress callback will be provided to the native code.
   ///
-  /// Returns a [Future] that completes with a success message when the model
-  /// is loaded successfully, or an error message if loading fails.
-  ///
-  /// Throws an [UnimplementedError] if the subclass does not override this method.
+  /// Returns the path to the model folder if the model is loaded successfully,
+  /// or throws a [WhisperKitError] if loading fails.
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart
@@ -62,8 +62,6 @@ abstract class FlutterWhisperKitPlatform extends PlatformInterface {
   ///   This is the Hugging Face repository where the model files are hosted.
   /// - [redownload]: Whether to force redownload the model even if it exists locally.
   ///   Set to true to ensure you have the latest version of the model.
-  /// - [modelDownloadPath]: Custom path where the model should be downloaded.
-  ///   If not provided, the model will be stored in the default location.
   /// - [hasProgressCallback]: Whether to provide a progress callback.
   ///   If true, the progress callback will be provided to the native code.
   ///
@@ -75,7 +73,6 @@ abstract class FlutterWhisperKitPlatform extends PlatformInterface {
     String? variant, {
     String? modelRepo,
     bool redownload = false,
-    String? modelDownloadPath,
     bool hasProgressCallback = false,
   }) {
     throw UnimplementedError('loadModel() has not been implemented.');

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart
@@ -50,14 +50,14 @@ class WhisperKitMessage {
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<String?> loadModel(String? variant, String? modelRepo, bool redownload, String? modelDownloadPath, bool hasProgressCallback) async {
+  Future<String?> loadModel(String? variant, String? modelRepo, bool redownload, bool hasProgressCallback) async {
     final String pigeonVar_channelName = 'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.loadModel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[variant, modelRepo, redownload, modelDownloadPath, hasProgressCallback]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[variant, modelRepo, redownload, hasProgressCallback]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart
@@ -50,7 +50,7 @@ class WhisperKitMessage {
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<String?> loadModel(String? variant, String? modelRepo, bool? redownload, String? modelDownloadPath, bool hasProgressCallback) async {
+  Future<String?> loadModel(String? variant, String? modelRepo, bool redownload, String? modelDownloadPath, bool hasProgressCallback) async {
     final String pigeonVar_channelName = 'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.loadModel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,

--- a/packages/flutter_whisper_kit/pigeons/whisper_kit_api.dart
+++ b/packages/flutter_whisper_kit/pigeons/whisper_kit_api.dart
@@ -14,7 +14,7 @@ abstract class WhisperKitMessage {
   String? loadModel(
     String? variant,
     String? modelRepo,
-    bool? redownload,
+    bool redownload,
     String? modelDownloadPath,
     bool hasProgressCallback,
   );

--- a/packages/flutter_whisper_kit/pigeons/whisper_kit_api.dart
+++ b/packages/flutter_whisper_kit/pigeons/whisper_kit_api.dart
@@ -15,7 +15,6 @@ abstract class WhisperKitMessage {
     String? variant,
     String? modelRepo,
     bool redownload,
-    String? modelDownloadPath,
     bool hasProgressCallback,
   );
   @async

--- a/packages/flutter_whisper_kit/test/test_utils/mock_method_channel.dart
+++ b/packages/flutter_whisper_kit/test/test_utils/mock_method_channel.dart
@@ -11,9 +11,9 @@ class MockMethodChannelFlutterWhisperkit
   @override
   Future<String?> loadModel(
     String? modelName, {
-    String? modelDownloadPath,
     String? modelRepo,
-    bool? redownload,
+    bool redownload = false,
+    bool hasProgressCallback = false,
   }) async {
     return mockLoadModelResponse;
   }

--- a/packages/flutter_whisper_kit/test/test_utils/mocks.dart
+++ b/packages/flutter_whisper_kit/test/test_utils/mocks.dart
@@ -11,8 +11,8 @@ class MockFlutterWhisperkitPlatform
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,
-    bool? redownload,
-    String? modelDownloadPath,
+    bool redownload = false,
+    bool hasProgressCallback = false,
   }) => Future.value('Model loaded');
 
   @override

--- a/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift
+++ b/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift
@@ -49,12 +49,12 @@ private class WhisperKitApiImpl: WhisperKitMessage {
   /// - Parameters:
   ///   - variant: The model variant to load (required)
   ///   - modelRepo: The repository to download the model from (optional)
-  ///   - redownload: Whether to force redownload the model (optional)
+  ///   - redownload: Whether to force redownload the model (required)
   ///   - modelDownloadPath: Custom path for model storage (optional)
-  ///   - hasProgressCallback: Indicates whether to enable progress updates during model download (optional)
+  ///   - hasProgressCallback: Indicates whether to enable progress updates during model download (required)
   ///   - completion: Callback with result of the operation
   func loadModel(
-    variant: String?, modelRepo: String?, redownload: Bool?, modelDownloadPath: String?, hasProgressCallback: Bool,
+    variant: String?, modelRepo: String?, redownload: Bool, modelDownloadPath: String?, hasProgressCallback: Bool,
     completion: @escaping (Result<String?, Error>) -> Void
   ) {
     guard let variant = variant else {
@@ -110,7 +110,7 @@ private class WhisperKitApiImpl: WhisperKitMessage {
         var modelFolder: URL?
         let localModels = await getLocalModels(path: modelDownloadPath)
 
-        if localModels.contains(variant) && !(redownload ?? false) {
+        if localModels.contains(variant) && !redownload {
           modelFolder = modelDirURL.appendingPathComponent(variant)
         } else {
           let downloadDestination = modelDirURL.appendingPathComponent(variant)

--- a/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift
+++ b/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift
@@ -89,7 +89,7 @@ private class WhisperKitApiImpl: WhisperKitMessage {
         var modelFolder: URL?
         let localModels = await getLocalModels()
         let modelDirURL = getModelFolderPath()
-        
+
         if localModels.contains(variant) && !redownload {
           modelFolder = modelDirURL.appendingPathComponent(variant)
         } else {
@@ -152,7 +152,7 @@ private class WhisperKitApiImpl: WhisperKitMessage {
           
           try await whisperKit.loadModels()
           
-          completion(.success("Model \(variant) loaded successfully"))
+          completion(.success(folder.path))
         } else {
           throw NSError(
             domain: "WhisperKitError", code: 1003,

--- a/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift
+++ b/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift
@@ -50,11 +50,10 @@ private class WhisperKitApiImpl: WhisperKitMessage {
   ///   - variant: The model variant to load (required)
   ///   - modelRepo: The repository to download the model from (optional)
   ///   - redownload: Whether to force redownload the model (required)
-  ///   - modelDownloadPath: Custom path for model storage (optional)
   ///   - hasProgressCallback: Indicates whether to enable progress updates during model download (required)
   ///   - completion: Callback with result of the operation
   func loadModel(
-    variant: String?, modelRepo: String?, redownload: Bool, modelDownloadPath: String?, hasProgressCallback: Bool,
+    variant: String?, modelRepo: String?, redownload: Bool, hasProgressCallback: Bool,
     completion: @escaping (Result<String?, Error>) -> Void
   ) {
     guard let variant = variant else {
@@ -68,26 +67,6 @@ private class WhisperKitApiImpl: WhisperKitMessage {
 
     Task {
       do {
-        let modelDirURL = getModelFolderPath(path: modelDownloadPath)
-
-        do {
-          if !FileManager.default.fileExists(atPath: modelDirURL.path) {
-            try FileManager.default.createDirectory(
-              at: modelDirURL, withIntermediateDirectories: true, attributes: nil)
-          }
-
-          let testFile = modelDirURL.appendingPathComponent("test_write_permission.txt")
-          try "test".write(to: testFile, atomically: true, encoding: .utf8)
-          try FileManager.default.removeItem(at: testFile)
-        } catch {
-          throw NSError(
-            domain: "WhisperKitError", code: 4001,
-            userInfo: [
-              NSLocalizedDescriptionKey:
-                "Cannot write to model directory: \(error.localizedDescription)"
-            ])
-        }
-
         if whisperKit == nil {
           let config = WhisperKitConfig(
             verbose: true,
@@ -108,8 +87,9 @@ private class WhisperKitApiImpl: WhisperKitMessage {
         }
 
         var modelFolder: URL?
-        let localModels = await getLocalModels(path: modelDownloadPath)
-
+        let localModels = await getLocalModels()
+        let modelDirURL = getModelFolderPath()
+        
         if localModels.contains(variant) && !redownload {
           modelFolder = modelDirURL.appendingPathComponent(variant)
         } else {
@@ -404,29 +384,15 @@ private class WhisperKitApiImpl: WhisperKitMessage {
 
   /// Gets the path to the WhisperKit models directory
   ///
-  /// - Parameter path: Optional custom path for model storage
   /// - Returns: URL to the WhisperKit models directory
-  private func getModelFolderPath(path: String?) -> URL {
-    if path == nil {
-      if let appSupport = FileManager.default.urls(
-        for: .applicationSupportDirectory, in: .userDomainMask
-      ).first {
-        return appSupport.appendingPathComponent("WhisperKitModels")
-      }
-      return getDocumentsDirectory().appendingPathComponent("WhisperKitModels")
-    } else {
-      let userPath = URL(fileURLWithPath: path!)
-      let testFile = userPath.appendingPathComponent("whisperkit_write_test.txt")
-      do {
-        try "test".write(to: testFile, atomically: true, encoding: .utf8)
-        try FileManager.default.removeItem(at: testFile)
-        return userPath.appendingPathComponent("WhisperKitModels")
-      } catch {
-        print("Cannot write to custom directory: \(error.localizedDescription)")
-      }
-      
-      return getDocumentsDirectory().appendingPathComponent("WhisperKitModels")
+  private func getModelFolderPath() -> URL {
+    if let appSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory, in: .userDomainMask
+    ).first {
+      return appSupport.appendingPathComponent("WhisperKitModels")
     }
+
+    return getDocumentsDirectory().appendingPathComponent("WhisperKitModels")
   }
 
   /// Gets the Documents directory
@@ -438,10 +404,9 @@ private class WhisperKitApiImpl: WhisperKitMessage {
 
   /// Gets the list of locally available models
   ///
-  /// - Parameter path: Optional custom path for model storage
   /// - Returns: Array of model names that are available locally
-  private func getLocalModels(path: String?) async -> [String] {
-    let modelPath = getModelFolderPath(path: path)
+  private func getLocalModels() async -> [String] {
+    let modelPath = getModelFolderPath()
     var localModels: [String] = []
 
     do {

--- a/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/WhisperKitMessage.g.swift
+++ b/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/WhisperKitMessage.g.swift
@@ -88,7 +88,7 @@ class WhisperKitMessagePigeonCodec: FlutterStandardMessageCodec, @unchecked Send
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol WhisperKitMessage {
-  func loadModel(variant: String?, modelRepo: String?, redownload: Bool?, modelDownloadPath: String?, hasProgressCallback: Bool, completion: @escaping (Result<String?, Error>) -> Void)
+  func loadModel(variant: String?, modelRepo: String?, redownload: Bool, modelDownloadPath: String?, hasProgressCallback: Bool, completion: @escaping (Result<String?, Error>) -> Void)
   func transcribeFromFile(filePath: String, options: [String: Any?], completion: @escaping (Result<String?, Error>) -> Void)
   func startRecording(options: [String: Any?], loop: Bool, completion: @escaping (Result<String?, Error>) -> Void)
   func stopRecording(loop: Bool, completion: @escaping (Result<String?, Error>) -> Void)
@@ -106,7 +106,7 @@ class WhisperKitMessageSetup {
         let args = message as! [Any?]
         let variantArg: String? = nilOrValue(args[0])
         let modelRepoArg: String? = nilOrValue(args[1])
-        let redownloadArg: Bool? = nilOrValue(args[2])
+        let redownloadArg = args[2] as! Bool
         let modelDownloadPathArg: String? = nilOrValue(args[3])
         let hasProgressCallbackArg = args[4] as! Bool
         api.loadModel(variant: variantArg, modelRepo: modelRepoArg, redownload: redownloadArg, modelDownloadPath: modelDownloadPathArg, hasProgressCallback: hasProgressCallbackArg) { result in

--- a/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/WhisperKitMessage.g.swift
+++ b/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/WhisperKitMessage.g.swift
@@ -88,7 +88,7 @@ class WhisperKitMessagePigeonCodec: FlutterStandardMessageCodec, @unchecked Send
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol WhisperKitMessage {
-  func loadModel(variant: String?, modelRepo: String?, redownload: Bool, modelDownloadPath: String?, hasProgressCallback: Bool, completion: @escaping (Result<String?, Error>) -> Void)
+  func loadModel(variant: String?, modelRepo: String?, redownload: Bool, hasProgressCallback: Bool, completion: @escaping (Result<String?, Error>) -> Void)
   func transcribeFromFile(filePath: String, options: [String: Any?], completion: @escaping (Result<String?, Error>) -> Void)
   func startRecording(options: [String: Any?], loop: Bool, completion: @escaping (Result<String?, Error>) -> Void)
   func stopRecording(loop: Bool, completion: @escaping (Result<String?, Error>) -> Void)
@@ -107,9 +107,8 @@ class WhisperKitMessageSetup {
         let variantArg: String? = nilOrValue(args[0])
         let modelRepoArg: String? = nilOrValue(args[1])
         let redownloadArg = args[2] as! Bool
-        let modelDownloadPathArg: String? = nilOrValue(args[3])
-        let hasProgressCallbackArg = args[4] as! Bool
-        api.loadModel(variant: variantArg, modelRepo: modelRepoArg, redownload: redownloadArg, modelDownloadPath: modelDownloadPathArg, hasProgressCallback: hasProgressCallbackArg) { result in
+        let hasProgressCallbackArg = args[3] as! Bool
+        api.loadModel(variant: variantArg, modelRepo: modelRepoArg, redownload: redownloadArg, hasProgressCallback: hasProgressCallbackArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/packages/flutter_whisper_kit_apple/test/test_utils/mock_method_channel.dart
+++ b/packages/flutter_whisper_kit_apple/test/test_utils/mock_method_channel.dart
@@ -43,8 +43,8 @@ class MockMethodChannelFlutterWhisperkit
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,
-    bool? redownload,
-    String? modelDownloadPath,
+    bool redownload = false,
+    bool hasProgressCallback = false,
   }) async {
     // Simulate progress updates through the stream
     for (int i = 0; i <= 10; i++) {

--- a/packages/flutter_whisper_kit_apple/test/test_utils/mock_whisper_kit_message.dart
+++ b/packages/flutter_whisper_kit_apple/test/test_utils/mock_whisper_kit_message.dart
@@ -7,12 +7,10 @@ class MockWhisperKitMessage extends FlutterWhisperKitPlatform {
   @override
   Future<String?> loadModel(
     String? variant, {
-    String? modelDownloadPath,
     String? modelRepo,
-    bool? redownload,
+    bool redownload = false,
+    bool hasProgressCallback = false,
   }) async {
-    // In a real implementation, we would use the modelDownloadPath parameter
-    // and report progress through the event channel
     return 'Model loaded successfully';
   }
 

--- a/packages/flutter_whisper_kit_apple/test/test_utils/mocks.dart
+++ b/packages/flutter_whisper_kit_apple/test/test_utils/mocks.dart
@@ -8,11 +8,9 @@ class MockFlutterWhisperkitPlatform extends FlutterWhisperKitPlatform {
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,
-    bool? redownload,
-    String? modelDownloadPath,
+    bool redownload = false,
+    bool hasProgressCallback = false,
   }) {
-    // In a real implementation, we would use the modelDownloadPath parameter
-    // and report progress through the modelProgressStream
     return Future.value('Model loaded');
   }
 


### PR DESCRIPTION
<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->

## Related Issue
<!-- Please specify the Issue that this PR will close -->
Close #xxx

## Description
<!-- このPRで行った変更内容を詳細に記載してください -->
This pull request refactors the `loadModel` method across the `flutter_whisper_kit` package to simplify its interface and improve functionality. The most significant changes include removing the `modelDownloadPath` parameter, making `redownload` a required boolean with a default value of `false`, and updating the return value to consistently provide the path to the model folder. Additionally, associated test utilities and platform-specific implementations have been updated to align with these changes.

### Simplification of `loadModel` Method:

* Removed the `modelDownloadPath` parameter from the `loadModel` method across all interfaces and implementations. The model folder path is now determined internally using a default directory. (`[[1]](diffhunk://#diff-5c256a11fd6174d588b038736449f50dfa0a36b03760badc3130fa60f673772bL35-L45)`, `[[2]](diffhunk://#diff-fbe462c263403520c74cdf73740ef8bf0deb2589e20e1d5d70cbcdace553ec17L126-L144)`, `[[3]](diffhunk://#diff-7490799dab041e3bca9aa6652c38fe2cba95bf46df0dfe602deb0a4c0ea5c974L65-R73)`, `[[4]](diffhunk://#diff-e183acb897ea19341813a5798757bd21f0397a56389c3d436d1469c17135048eL53-R60)`, `[[5]](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L407-L430)`)

* Changed the `redownload` parameter to be a required boolean with a default value of `false`, ensuring more predictable behavior. (`[[1]](diffhunk://#diff-5c256a11fd6174d588b038736449f50dfa0a36b03760badc3130fa60f673772bL35-L45)`, `[[2]](diffhunk://#diff-fbe462c263403520c74cdf73740ef8bf0deb2589e20e1d5d70cbcdace553ec17L126-L144)`, `[[3]](diffhunk://#diff-7490799dab041e3bca9aa6652c38fe2cba95bf46df0dfe602deb0a4c0ea5c974L65-R73)`, `[[4]](diffhunk://#diff-185a95ee741d35a91e226ec7a004b3dc7a8c0ac067fd158ee37ecf13f40c8589L17-R17)`)

* Updated the method's return value to consistently provide the path to the model folder when the model is successfully loaded. (`[[1]](diffhunk://#diff-5c256a11fd6174d588b038736449f50dfa0a36b03760badc3130fa60f673772bL35-L45)`, `[[2]](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L175-R155)`, `[[3]](diffhunk://#diff-5f7ae101ffc512c4ac42f80ea8205393e7ff0e51b964c29bad70709780ae5d93L91-R91)`)

### Platform-Specific Adjustments:

* Refactored the Apple platform implementation to remove custom model directory handling and rely on default paths for the model folder. This includes simplifying the logic for checking and creating directories. (`[[1]](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L71-L90)`, `[[2]](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L111-R93)`, `[[3]](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L407-L430)`, `[[4]](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L441-R409)`)

* Updated the Pigeon-generated code to reflect the removal of the `modelDownloadPath` parameter and the new signature of the `loadModel` method. (`[[1]](diffhunk://#diff-5f7ae101ffc512c4ac42f80ea8205393e7ff0e51b964c29bad70709780ae5d93L91-R91)`, `[[2]](diffhunk://#diff-5f7ae101ffc512c4ac42f80ea8205393e7ff0e51b964c29bad70709780ae5d93L109-R111)`)

### Test Utility Updates:

* Updated mock classes and test utilities to align with the new `loadModel` method signature, removing the `modelDownloadPath` parameter and adding default values for `redownload` and `hasProgressCallback`. (`[[1]](diffhunk://#diff-5c7ffc71045ebbbcf35a66493c6442477945864dfbc807e25219e8f6bc4abb0dL14-R16)`, `[[2]](diffhunk://#diff-79ac6d0672ab340285701be0706fae6d671848e3658acba8063643cd1ffb2e31L14-R15)`, `[[3]](diffhunk://#diff-097e6c7426b63c765a58287e4a90b9480783902caa51d931d9d3dbf66ef57d06L46-R47)`, `[[4]](diffhunk://#diff-276c98a887ad94356a6db06378efaf4777c2419c8b138266edcf51a3c8d23e1bL10-L15)`, `[[5]](diffhunk://#diff-01c183ce961033500d3d50d217bb0e6ff80bfebedaebcdfc6492af2ef8428507L11-L15)`)
## Checklist

- [ ]  xxx