### PR TITLE
delete hasProgressCallback property

### DIFF
--- a/packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart
+++ b/packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart
@@ -60,7 +60,6 @@ class FlutterWhisperKit {
         variant,
         modelRepo: modelRepo,
         redownload: redownload,
-        hasProgressCallback: onProgress != null,
       );
     } on PlatformException catch (e) {
       // Convert platform exceptions to WhisperKitError for better error handling

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart
@@ -123,8 +123,6 @@ class MethodChannelFlutterWhisperKit extends FlutterWhisperKitPlatform {
   /// - [variant]: The model variant to load (e.g., 'tiny-en', 'base', 'small', 'medium', 'large-v2').
   /// - [modelRepo]: The repository to download the model from.
   /// - [redownload]: Whether to force redownload the model even if it exists locally.
-  /// - [hasProgressCallback]: Whether to provide a progress callback.
-  ///   If true, the progress callback will be provided to the native code.
   ///
   /// Returns the path to the model folder if the model is loaded successfully,
   /// or an error message if loading fails.
@@ -133,14 +131,8 @@ class MethodChannelFlutterWhisperKit extends FlutterWhisperKitPlatform {
     String? variant, {
     String? modelRepo,
     bool redownload = false,
-    bool hasProgressCallback = false,
   }) async {
-    return _whisperKitMessage.loadModel(
-      variant,
-      modelRepo,
-      redownload,
-      hasProgressCallback,
-    );
+    return _whisperKitMessage.loadModel(variant, modelRepo, redownload);
   }
 
   /// Transcribes an audio file at the specified path.

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart
@@ -62,8 +62,6 @@ abstract class FlutterWhisperKitPlatform extends PlatformInterface {
   ///   This is the Hugging Face repository where the model files are hosted.
   /// - [redownload]: Whether to force redownload the model even if it exists locally.
   ///   Set to true to ensure you have the latest version of the model.
-  /// - [hasProgressCallback]: Whether to provide a progress callback.
-  ///   If true, the progress callback will be provided to the native code.
   ///
   /// Returns the path to the model folder if the model is loaded successfully,
   /// or throws a [WhisperKitError] if loading fails.
@@ -71,7 +69,6 @@ abstract class FlutterWhisperKitPlatform extends PlatformInterface {
     String? variant, {
     String? modelRepo,
     bool redownload = false,
-    bool hasProgressCallback = false,
   }) {
     throw UnimplementedError('loadModel() has not been implemented.');
   }

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart
@@ -50,14 +50,14 @@ class WhisperKitMessage {
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<String?> loadModel(String? variant, String? modelRepo, bool redownload, bool hasProgressCallback) async {
+  Future<String?> loadModel(String? variant, String? modelRepo, bool redownload) async {
     final String pigeonVar_channelName = 'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.loadModel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[variant, modelRepo, redownload, hasProgressCallback]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[variant, modelRepo, redownload]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/packages/flutter_whisper_kit/pigeons/whisper_kit_api.dart
+++ b/packages/flutter_whisper_kit/pigeons/whisper_kit_api.dart
@@ -11,12 +11,7 @@ import 'package:pigeon/pigeon.dart';
 @HostApi()
 abstract class WhisperKitMessage {
   @async
-  String? loadModel(
-    String? variant,
-    String? modelRepo,
-    bool redownload,
-    bool hasProgressCallback,
-  );
+  String? loadModel(String? variant, String? modelRepo, bool redownload);
   @async
   String? transcribeFromFile(String filePath, Map<String, Object?> options);
   @async

--- a/packages/flutter_whisper_kit/test/test_utils/mock_method_channel.dart
+++ b/packages/flutter_whisper_kit/test/test_utils/mock_method_channel.dart
@@ -13,7 +13,6 @@ class MockMethodChannelFlutterWhisperkit
     String? modelName, {
     String? modelRepo,
     bool redownload = false,
-    bool hasProgressCallback = false,
   }) async {
     return mockLoadModelResponse;
   }

--- a/packages/flutter_whisper_kit/test/test_utils/mocks.dart
+++ b/packages/flutter_whisper_kit/test/test_utils/mocks.dart
@@ -12,7 +12,6 @@ class MockFlutterWhisperkitPlatform
     String? variant, {
     String? modelRepo,
     bool redownload = false,
-    bool hasProgressCallback = false,
   }) => Future.value('Model loaded');
 
   @override

--- a/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift
+++ b/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift
@@ -50,10 +50,9 @@ private class WhisperKitApiImpl: WhisperKitMessage {
   ///   - variant: The model variant to load (required)
   ///   - modelRepo: The repository to download the model from (optional)
   ///   - redownload: Whether to force redownload the model (required)
-  ///   - hasProgressCallback: Indicates whether to enable progress updates during model download (required)
   ///   - completion: Callback with result of the operation
   func loadModel(
-    variant: String?, modelRepo: String?, redownload: Bool, hasProgressCallback: Bool,
+    variant: String?, modelRepo: String?, redownload: Bool,
     completion: @escaping (Result<String?, Error>) -> Void
   ) {
     guard let variant = variant else {
@@ -104,11 +103,11 @@ private class WhisperKitApiImpl: WhisperKitMessage {
             modelFolder = try await WhisperKit.download(
               variant: variant,
               from: modelRepo ?? "argmaxinc/whisperkit-coreml",
-              progressCallback: hasProgressCallback ? { progress in
+              progressCallback:  { progress in
                 if let streamHandler = WhisperKitApiImpl.modelProgressStreamHandler as? ModelProgressStreamHandler {
                   streamHandler.sendProgress(progress)
                 }
-              } : nil,
+              },
             )
             // Save the downloaded model folder to the specified model directory
             if let downloadedFolder = modelFolder {

--- a/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/WhisperKitMessage.g.swift
+++ b/packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/WhisperKitMessage.g.swift
@@ -88,7 +88,7 @@ class WhisperKitMessagePigeonCodec: FlutterStandardMessageCodec, @unchecked Send
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol WhisperKitMessage {
-  func loadModel(variant: String?, modelRepo: String?, redownload: Bool, hasProgressCallback: Bool, completion: @escaping (Result<String?, Error>) -> Void)
+  func loadModel(variant: String?, modelRepo: String?, redownload: Bool, completion: @escaping (Result<String?, Error>) -> Void)
   func transcribeFromFile(filePath: String, options: [String: Any?], completion: @escaping (Result<String?, Error>) -> Void)
   func startRecording(options: [String: Any?], loop: Bool, completion: @escaping (Result<String?, Error>) -> Void)
   func stopRecording(loop: Bool, completion: @escaping (Result<String?, Error>) -> Void)
@@ -107,8 +107,7 @@ class WhisperKitMessageSetup {
         let variantArg: String? = nilOrValue(args[0])
         let modelRepoArg: String? = nilOrValue(args[1])
         let redownloadArg = args[2] as! Bool
-        let hasProgressCallbackArg = args[3] as! Bool
-        api.loadModel(variant: variantArg, modelRepo: modelRepoArg, redownload: redownloadArg, hasProgressCallback: hasProgressCallbackArg) { result in
+        api.loadModel(variant: variantArg, modelRepo: modelRepoArg, redownload: redownloadArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/packages/flutter_whisper_kit_apple/test/test_utils/mock_method_channel.dart
+++ b/packages/flutter_whisper_kit_apple/test/test_utils/mock_method_channel.dart
@@ -44,7 +44,6 @@ class MockMethodChannelFlutterWhisperkit
     String? variant, {
     String? modelRepo,
     bool redownload = false,
-    bool hasProgressCallback = false,
   }) async {
     // Simulate progress updates through the stream
     for (int i = 0; i <= 10; i++) {

--- a/packages/flutter_whisper_kit_apple/test/test_utils/mock_whisper_kit_message.dart
+++ b/packages/flutter_whisper_kit_apple/test/test_utils/mock_whisper_kit_message.dart
@@ -9,7 +9,6 @@ class MockWhisperKitMessage extends FlutterWhisperKitPlatform {
     String? variant, {
     String? modelRepo,
     bool redownload = false,
-    bool hasProgressCallback = false,
   }) async {
     return 'Model loaded successfully';
   }

--- a/packages/flutter_whisper_kit_apple/test/test_utils/mocks.dart
+++ b/packages/flutter_whisper_kit_apple/test/test_utils/mocks.dart
@@ -9,7 +9,6 @@ class MockFlutterWhisperkitPlatform extends FlutterWhisperKitPlatform {
     String? variant, {
     String? modelRepo,
     bool redownload = false,
-    bool hasProgressCallback = false,
   }) {
     return Future.value('Model loaded');
   }


### PR DESCRIPTION
<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->

## Related Issue
<!-- Please specify the Issue that this PR will close -->
Close #xxx

## Description
<!-- このPRで行った変更内容を詳細に記載してください -->
This pull request removes the `hasProgressCallback` parameter from the `loadModel` method across multiple files in the `flutter_whisper_kit` package. The change simplifies the method signature and eliminates the need to explicitly specify whether progress updates are enabled, as progress callbacks are now always included by default.

### Removal of `hasProgressCallback` Parameter:

* [`packages/flutter_whisper_kit/lib/src/flutter_whisper_kit.dart`](diffhunk://#diff-5c256a11fd6174d588b038736449f50dfa0a36b03760badc3130fa60f673772bL63): Removed the `hasProgressCallback` parameter from the `loadModel` method call.
* [`packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_method_channel.dart`](diffhunk://#diff-fbe462c263403520c74cdf73740ef8bf0deb2589e20e1d5d70cbcdace553ec17L126-L127): Updated the `loadModel` method to no longer include the `hasProgressCallback` parameter in its signature or documentation. [[1]](diffhunk://#diff-fbe462c263403520c74cdf73740ef8bf0deb2589e20e1d5d70cbcdace553ec17L126-L127) [[2]](diffhunk://#diff-fbe462c263403520c74cdf73740ef8bf0deb2589e20e1d5d70cbcdace553ec17L136-R135)
* [`packages/flutter_whisper_kit/lib/src/platform_specifics/flutter_whisper_kit_platform_interface.dart`](diffhunk://#diff-7490799dab041e3bca9aa6652c38fe2cba95bf46df0dfe602deb0a4c0ea5c974L65-L74): Removed the `hasProgressCallback` parameter from the `loadModel` method in the platform interface.

### Updates to Generated and Platform-Specific Code:

* [`packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart`](diffhunk://#diff-e183acb897ea19341813a5798757bd21f0397a56389c3d436d1469c17135048eL53-R60): Adjusted the `loadModel` method to exclude the `hasProgressCallback` parameter in the generated Pigeon code.
* [`packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/FlutterWhisperKitApplePlugin.swift`](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L53-R55): Removed the `hasProgressCallback` parameter from the `loadModel` method and ensured progress updates are always enabled. [[1]](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L53-R55) [[2]](diffhunk://#diff-96f299b4def8863548c20ab157d42caaaffec9b3171b15a2d2c8559faa2e5151L107-R110)
* [`packages/flutter_whisper_kit_apple/darwin/flutter_whisper_kit_apple/Sources/flutter_whisper_kit_apple/WhisperKitMessage.g.swift`](diffhunk://#diff-5f7ae101ffc512c4ac42f80ea8205393e7ff0e51b964c29bad70709780ae5d93L91-R91): Updated the `loadModel` method in the generated Swift code to remove the `hasProgressCallback` parameter. [[1]](diffhunk://#diff-5f7ae101ffc512c4ac42f80ea8205393e7ff0e51b964c29bad70709780ae5d93L91-R91) [[2]](diffhunk://#diff-5f7ae101ffc512c4ac42f80ea8205393e7ff0e51b964c29bad70709780ae5d93L110-R110)

### Test Code Adjustments:

* [`packages/flutter_whisper_kit/test/test_utils/mock_method_channel.dart`](diffhunk://#diff-5c7ffc71045ebbbcf35a66493c6442477945864dfbc807e25219e8f6bc4abb0dL16): Updated mock implementations to remove the `hasProgressCallback` parameter. [[1]](diffhunk://#diff-5c7ffc71045ebbbcf35a66493c6442477945864dfbc807e25219e8f6bc4abb0dL16) [[2]](diffhunk://#diff-097e6c7426b63c765a58287e4a90b9480783902caa51d931d9d3dbf66ef57d06L47)
* [`packages/flutter_whisper_kit/test/test_utils/mocks.dart`](diffhunk://#diff-79ac6d0672ab340285701be0706fae6d671848e3658acba8063643cd1ffb2e31L15): Adjusted mock platform implementations to align with the updated `loadModel` method signature.
* [`packages/flutter_whisper_kit_apple/test/test_utils/mock_whisper_kit_message.dart`](diffhunk://#diff-276c98a887ad94356a6db06378efaf4777c2419c8b138266edcf51a3c8d23e1bL12): Removed the `hasProgressCallback` parameter from mock implementations in the Apple-specific test utilities. [[1]](diffhunk://#diff-276c98a887ad94356a6db06378efaf4777c2419c8b138266edcf51a3c8d23e1bL12) [[2]](diffhunk://#diff-01c183ce961033500d3d50d217bb0e6ff80bfebedaebcdfc6492af2ef8428507L12)

These changes streamline the API, ensuring that progress updates are always available without requiring additional configuration.
## Checklist

- [ ]  xxx