### PR TITLE
Remove model loading tests and related documentation from README file…

### DIFF
--- a/packages/flutter_whisper_kit/test/README.md
+++ b/packages/flutter_whisper_kit/test/README.md
@@ -17,10 +17,6 @@ The tests are organized into the following files:
 
 ### Feature Tests
 
-- **model_loader_test.dart**: Tests the model loading functionality.
-  - Verifies that models can be loaded with default and custom options
-  - Tests the WhisperKitModelLoader utility class
-
 - **transcription_test.dart**: Tests the file transcription functionality.
   - Verifies that audio files can be transcribed with default and custom options
   - Tests handling of invalid file paths

--- a/packages/flutter_whisper_kit_apple/test/README.md
+++ b/packages/flutter_whisper_kit_apple/test/README.md
@@ -11,7 +11,6 @@ The tests are organized into the following files:
 - **flutter_whisperkit_apple_test.dart**: Tests the main plugin interface and verifies that the plugin correctly delegates calls to the platform interface.
   - Validates that the default platform implementation is the method channel implementation
   - Tests the model loading functionality
-  - Tests the WhisperKitModelLoader utility class
 
 - **flutter_whisperkit_apple_method_channel_test.dart**: Tests the method channel implementation that communicates with the native code.
   - Verifies that the method channel correctly handles method calls and returns expected values

--- a/packages/flutter_whisper_kit_apple/test/flutter_whisperkit_apple_test.dart
+++ b/packages/flutter_whisper_kit_apple/test/flutter_whisperkit_apple_test.dart
@@ -58,16 +58,5 @@ void main() {
       },
       timeout: const Timeout(Duration(seconds: 5)),
     );
-
-    group('WhisperKitModelLoader', () {
-      test('loads model and returns success message', () async {
-        // Arrange
-        setUpMockPlatform();
-        final modelLoader = WhisperKitModelLoader();
-
-        // Act & Assert
-        expect(await modelLoader.loadModel(variant: 'tiny-en'), 'Model loaded');
-      });
-    });
   });
 }


### PR DESCRIPTION
…s in flutter_whisper_kit and flutter_whisper_kit_apple. This streamlines the test descriptions and focuses on relevant functionality.

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->

## Related Issue
<!-- Please specify the Issue that this PR will close -->
Close #xxx

## Description
<!-- このPRで行った変更内容を詳細に記載してください -->
This pull request removes tests and documentation related to the `WhisperKitModelLoader` utility class across multiple files. The changes simplify the test files by eliminating references to this class, which appears to no longer be in use.

### Documentation updates:

* [`packages/flutter_whisper_kit/test/README.md`](diffhunk://#diff-6f7b2190e6677094dd05ecdca1f6bb394dfda6199322d239ebeececa1124836fL20-L23): Removed the section describing tests for the `WhisperKitModelLoader` utility class in the feature tests.
* [`packages/flutter_whisper_kit_apple/test/README.md`](diffhunk://#diff-a196750703d5f64140d2979f6d4a1de5f30686d76e577ce81b783206791b7777L14): Removed the mention of `WhisperKitModelLoader` tests from the main plugin test documentation.

### Test code cleanup:

* [`packages/flutter_whisper_kit_apple/test/flutter_whisperkit_apple_test.dart`](diffhunk://#diff-a5147e8d2de3aba25903ff5bdb9272ce310588dddeb8d33d7bc18f2229d07997L61-L71): Removed the `WhisperKitModelLoader` test group, including the test for loading a model and returning a success message.
## Checklist

- [ ]  xxx