### PR TITLE
fix pub status

### DIFF
--- a/packages/flutter_whisper_kit/example/test/app_integration_test.dart
+++ b/packages/flutter_whisper_kit/example/test/app_integration_test.dart
@@ -5,37 +5,38 @@ import 'package:flutter_whisper_kit_example/main.dart';
 void main() {
   testWidgets('Full app integration test', (WidgetTester tester) async {
     // Build our app and trigger a frame
-    await tester.pumpWidget(const MaterialApp(
-      home: MyApp(),
-    ));
+    await tester.pumpWidget(const MaterialApp(home: MyApp()));
 
     // Initially, the app should show the title
     expect(find.text('Flutter WhisperKit Example'), findsOneWidget);
-    
+
     // Verify dropdown buttons are present
     expect(find.byType(DropdownButton<String>), findsWidgets);
-    
+
     // Find the Load Model button
     final loadModelButton = find.widgetWithText(ElevatedButton, 'Load Model');
     expect(loadModelButton, findsOneWidget);
-    
+
     // Tap the Load Model button to start loading
     await tester.tap(loadModelButton);
     await tester.pump();
-    
+
     // The app should show loading indicators initially
     expect(find.byType(LinearProgressIndicator), findsOneWidget);
-    
+
     // Wait for a frame to be rendered
     await tester.pump(const Duration(milliseconds: 300));
-    
+
     // After loading, the transcribe button should be visible
-    expect(find.widgetWithText(ElevatedButton, 'Transcribe from File'), findsOneWidget);
-    
+    expect(
+      find.widgetWithText(ElevatedButton, 'Transcribe from File'),
+      findsOneWidget,
+    );
+
     // Instead of interacting with dropdowns which may cause timeouts,
     // just verify that the app has the expected structure
     expect(find.byType(ElevatedButton), findsWidgets);
-    
+
     // Verify the app doesn't crash and shows expected sections
     expect(find.text('File Transcription'), findsOneWidget);
     expect(find.text('Real-time Transcription'), findsOneWidget);

--- a/packages/flutter_whisper_kit/example/test/file_transcription_test.dart
+++ b/packages/flutter_whisper_kit/example/test/file_transcription_test.dart
@@ -7,67 +7,90 @@ import 'package:flutter_whisper_kit_example/main.dart';
 
 void main() {
   group('FileTranscriptionSection', () {
-    testWidgets('displays initial state correctly', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: FileTranscriptionSection(
-            isModelLoaded: false,
-            isTranscribingFile: false,
-            fileTranscriptionText: '',
-            fileTranscriptionResult: null,
-            onTranscribePressed: () {},
+    testWidgets('displays initial state correctly', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: FileTranscriptionSection(
+              isModelLoaded: false,
+              isTranscribingFile: false,
+              fileTranscriptionText: '',
+              fileTranscriptionResult: null,
+              onTranscribePressed: () {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Verify initial UI elements
       expect(find.text('File Transcription'), findsOneWidget);
-      expect(find.text('Press the button to transcribe a file'), findsOneWidget);
-      
+      expect(
+        find.text('Press the button to transcribe a file'),
+        findsOneWidget,
+      );
+
       // Button should be disabled when model is not loaded
-      final buttonFinder = find.widgetWithText(ElevatedButton, 'Transcribe from File');
+      final buttonFinder = find.widgetWithText(
+        ElevatedButton,
+        'Transcribe from File',
+      );
       expect(buttonFinder, findsOneWidget);
       expect(tester.widget<ElevatedButton>(buttonFinder).enabled, isFalse);
     });
 
-    testWidgets('enables button when model is loaded', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: FileTranscriptionSection(
-            isModelLoaded: true,
-            isTranscribingFile: false,
-            fileTranscriptionText: '',
-            fileTranscriptionResult: null,
-            onTranscribePressed: () {},
+    testWidgets('enables button when model is loaded', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: FileTranscriptionSection(
+              isModelLoaded: true,
+              isTranscribingFile: false,
+              fileTranscriptionText: '',
+              fileTranscriptionResult: null,
+              onTranscribePressed: () {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Button should be enabled when model is loaded
-      final buttonFinder = find.widgetWithText(ElevatedButton, 'Transcribe from File');
+      final buttonFinder = find.widgetWithText(
+        ElevatedButton,
+        'Transcribe from File',
+      );
       expect(buttonFinder, findsOneWidget);
       expect(tester.widget<ElevatedButton>(buttonFinder).enabled, isTrue);
     });
 
-    testWidgets('shows loading state during transcription', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: FileTranscriptionSection(
-            isModelLoaded: true,
-            isTranscribingFile: true,
-            fileTranscriptionText: 'Transcribing file...',
-            fileTranscriptionResult: null,
-            onTranscribePressed: () {},
+    testWidgets('shows loading state during transcription', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: FileTranscriptionSection(
+              isModelLoaded: true,
+              isTranscribingFile: true,
+              fileTranscriptionText: 'Transcribing file...',
+              fileTranscriptionResult: null,
+              onTranscribePressed: () {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Button should show loading text
       expect(find.text('Transcribing...'), findsOneWidget);
       expect(find.text('Transcribing file...'), findsOneWidget);
     });
 
-    testWidgets('displays transcription results correctly', (WidgetTester tester) async {
+    testWidgets('displays transcription results correctly', (
+      WidgetTester tester,
+    ) async {
       final mockResult = TranscriptionResult(
         text: 'Hello world',
         segments: [
@@ -90,30 +113,32 @@ void main() {
           inputAudioSeconds: 0.75, // This will give a realTimeFactor of 2.0
         ),
       );
-      
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: FileTranscriptionSection(
-            isModelLoaded: true,
-            isTranscribingFile: false,
-            fileTranscriptionText: 'Hello world',
-            fileTranscriptionResult: mockResult,
-            onTranscribePressed: () {},
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: FileTranscriptionSection(
+              isModelLoaded: true,
+              isTranscribingFile: false,
+              fileTranscriptionText: 'Hello world',
+              fileTranscriptionResult: mockResult,
+              onTranscribePressed: () {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Verify transcription text is displayed
       expect(find.text('Hello world'), findsOneWidget);
-      
+
       // Verify language detection is displayed
       expect(find.text('Detected Language:'), findsOneWidget);
       expect(find.text('en'), findsOneWidget);
-      
+
       // Verify segments are displayed
       expect(find.text('Segments:'), findsOneWidget);
       expect(find.text('[0.00s - 2.00s]: Hello world'), findsOneWidget);
-      
+
       // Verify performance metrics are displayed
       expect(find.text('Performance:'), findsOneWidget);
       expect(find.text('Real-time factor: 2.00x'), findsOneWidget);

--- a/packages/flutter_whisper_kit/example/test/model_loading_test.dart
+++ b/packages/flutter_whisper_kit/example/test/model_loading_test.dart
@@ -5,62 +5,68 @@ import 'test_utils/mocks.dart';
 
 void main() {
   group('ModelLoadingIndicator', () {
-    testWidgets('displays loading progress correctly', (WidgetTester tester) async {
+    testWidgets('displays loading progress correctly', (
+      WidgetTester tester,
+    ) async {
       final mockWhisperKit = MockFlutterWhisperKit();
-      
+
       // Create a future that completes when the model is loaded
       final asyncLoadModel = mockWhisperKit.loadModel('tiny-en');
-      
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: TestModelLoadingIndicator(
-            asyncLoadModel: asyncLoadModel,
-            modelProgressStream: mockWhisperKit.modelProgressStream,
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TestModelLoadingIndicator(
+              asyncLoadModel: asyncLoadModel,
+              modelProgressStream: mockWhisperKit.modelProgressStream,
+            ),
           ),
         ),
-      ));
+      );
 
       // Initial state should show progress indicator
       expect(find.byType(LinearProgressIndicator), findsOneWidget);
-      
+
       // Wait for progress to be displayed
       await tester.pump();
-      
+
       // Verify progress indicator is shown
       expect(find.byType(LinearProgressIndicator), findsOneWidget);
-      
+
       // Allow model loading to complete
       await tester.pump(const Duration(milliseconds: 200));
-      
+
       // Instead of checking for LinearProgressIndicator which may not be present,
       // just check that the test completes successfully
       expect(true, isTrue);
-      
+
       // Complete the future
       await tester.pumpAndSettle();
-      
+
       // Should show success message
       expect(find.text('Model loaded successfully'), findsOneWidget);
-      
+
       mockWhisperKit.dispose();
     });
-    
+
     testWidgets('handles errors in model loading', (WidgetTester tester) async {
       // Create a future that fails but wrap it in a try-catch to prevent test failure
       final asyncLoadModel = Future<String?>.value('Error loading model');
-      
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: TestModelLoadingIndicator(
-            asyncLoadModel: asyncLoadModel,
-            modelProgressStream: const Stream.empty(),
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TestModelLoadingIndicator(
+              asyncLoadModel: asyncLoadModel,
+              modelProgressStream: const Stream.empty(),
+            ),
           ),
         ),
-      ));
+      );
 
       // Complete the future
       await tester.pump();
-      
+
       // Should show success message since we're using a value future now
       expect(find.text('Model loaded successfully'), findsOneWidget);
     });

--- a/packages/flutter_whisper_kit/example/test/model_selection_test.dart
+++ b/packages/flutter_whisper_kit/example/test/model_selection_test.dart
@@ -7,34 +7,40 @@ import 'package:flutter_whisper_kit_example/main.dart';
 void main() {
   group('ModelSelectionDropdown', () {
     testWidgets('displays correct initial model', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: ModelSelectionDropdown(
-            selectedModel: 'tiny-en',
-            modelVariants: const ['tiny-en', 'base', 'small'],
-            onModelChanged: (_) {},
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ModelSelectionDropdown(
+              selectedModel: 'tiny-en',
+              modelVariants: const ['tiny-en', 'base', 'small'],
+              onModelChanged: (_) {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Verify the selected model is displayed
       expect(find.text('tiny-en'), findsOneWidget);
     });
 
-    testWidgets('calls onModelChanged when selection changes', (WidgetTester tester) async {
+    testWidgets('calls onModelChanged when selection changes', (
+      WidgetTester tester,
+    ) async {
       String selectedModel = 'tiny-en';
-      
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: ModelSelectionDropdown(
-            selectedModel: selectedModel,
-            modelVariants: const ['tiny-en', 'base', 'small'],
-            onModelChanged: (String newModel) {
-              selectedModel = newModel;
-            },
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ModelSelectionDropdown(
+              selectedModel: selectedModel,
+              modelVariants: const ['tiny-en', 'base', 'small'],
+              onModelChanged: (String newModel) {
+                selectedModel = newModel;
+              },
+            ),
           ),
         ),
-      ));
+      );
 
       // Open the dropdown
       await tester.tap(find.byType(DropdownButton<String>));
@@ -50,33 +56,41 @@ void main() {
   });
 
   group('LanguageSelectionDropdown', () {
-    testWidgets('displays correct initial language', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: LanguageSelectionDropdown(
-            selectedLanguage: 'en',
-            onLanguageChanged: (_) {},
+    testWidgets('displays correct initial language', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: LanguageSelectionDropdown(
+              selectedLanguage: 'en',
+              onLanguageChanged: (_) {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Verify the selected language is displayed (in dropdown format)
       expect(find.text('en (English)'), findsOneWidget);
     });
 
-    testWidgets('calls onLanguageChanged when selection changes', (WidgetTester tester) async {
+    testWidgets('calls onLanguageChanged when selection changes', (
+      WidgetTester tester,
+    ) async {
       String selectedLanguage = 'en';
-      
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: LanguageSelectionDropdown(
-            selectedLanguage: selectedLanguage,
-            onLanguageChanged: (String newLanguage) {
-              selectedLanguage = newLanguage;
-            },
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: LanguageSelectionDropdown(
+              selectedLanguage: selectedLanguage,
+              onLanguageChanged: (String newLanguage) {
+                selectedLanguage = newLanguage;
+              },
+            ),
           ),
         ),
-      ));
+      );
 
       // Open the dropdown
       await tester.tap(find.byType(DropdownButton<String>));

--- a/packages/flutter_whisper_kit/example/test/realtime_transcription_test.dart
+++ b/packages/flutter_whisper_kit/example/test/realtime_transcription_test.dart
@@ -7,68 +7,86 @@ import 'package:flutter_whisper_kit_example/main.dart';
 
 void main() {
   group('RealTimeTranscriptionSection', () {
-    testWidgets('displays initial state correctly', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: RealTimeTranscriptionSection(
-            isModelLoaded: false,
-            isRecording: false,
-            transcriptionText: '',
-            segments: const [],
-            onRecordPressed: () {},
+    testWidgets('displays initial state correctly', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: RealTimeTranscriptionSection(
+              isModelLoaded: false,
+              isRecording: false,
+              transcriptionText: '',
+              segments: const [],
+              onRecordPressed: () {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Verify initial UI elements
       expect(find.text('Real-time Transcription'), findsOneWidget);
       expect(find.text('No segments'), findsOneWidget);
       expect(find.text('Press the button to start recording'), findsOneWidget);
-      
+
       // Button should be disabled when model is not loaded
-      final buttonFinder = find.widgetWithText(ElevatedButton, 'Start Recording');
+      final buttonFinder = find.widgetWithText(
+        ElevatedButton,
+        'Start Recording',
+      );
       expect(buttonFinder, findsOneWidget);
       expect(tester.widget<ElevatedButton>(buttonFinder).enabled, isFalse);
     });
 
-    testWidgets('enables button when model is loaded', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: RealTimeTranscriptionSection(
-            isModelLoaded: true,
-            isRecording: false,
-            transcriptionText: '',
-            segments: const [],
-            onRecordPressed: () {},
+    testWidgets('enables button when model is loaded', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: RealTimeTranscriptionSection(
+              isModelLoaded: true,
+              isRecording: false,
+              transcriptionText: '',
+              segments: const [],
+              onRecordPressed: () {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Button should be enabled when model is loaded
-      final buttonFinder = find.widgetWithText(ElevatedButton, 'Start Recording');
+      final buttonFinder = find.widgetWithText(
+        ElevatedButton,
+        'Start Recording',
+      );
       expect(buttonFinder, findsOneWidget);
       expect(tester.widget<ElevatedButton>(buttonFinder).enabled, isTrue);
     });
 
     testWidgets('shows recording state correctly', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: RealTimeTranscriptionSection(
-            isModelLoaded: true,
-            isRecording: true,
-            transcriptionText: 'Test recording',
-            segments: const [],
-            onRecordPressed: () {},
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: RealTimeTranscriptionSection(
+              isModelLoaded: true,
+              isRecording: true,
+              transcriptionText: 'Test recording',
+              segments: const [],
+              onRecordPressed: () {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Button should show stop recording text
       expect(find.text('Stop Recording'), findsOneWidget);
       expect(find.text('Test recording'), findsOneWidget);
     });
 
-    testWidgets('displays transcription segments correctly', (WidgetTester tester) async {
+    testWidgets('displays transcription segments correctly', (
+      WidgetTester tester,
+    ) async {
       final segments = [
         TranscriptionSegment(
           id: 0,
@@ -95,22 +113,24 @@ void main() {
           noSpeechProb: 0.1,
         ),
       ];
-      
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: RealTimeTranscriptionSection(
-            isModelLoaded: true,
-            isRecording: true,
-            transcriptionText: 'Hello World',
-            segments: segments,
-            onRecordPressed: () {},
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: RealTimeTranscriptionSection(
+              isModelLoaded: true,
+              isRecording: true,
+              transcriptionText: 'Hello World',
+              segments: segments,
+              onRecordPressed: () {},
+            ),
           ),
         ),
-      ));
+      );
 
       // Verify transcription text is displayed
       expect(find.text('Hello World'), findsOneWidget);
-      
+
       // Verify segments are displayed
       expect(find.text('[0.00s - 2.00s]: Hello'), findsOneWidget);
       expect(find.text('[2.00s - 4.00s]: World'), findsOneWidget);

--- a/packages/flutter_whisper_kit/example/test/test_utils/mocks.dart
+++ b/packages/flutter_whisper_kit/example/test/test_utils/mocks.dart
@@ -6,9 +6,11 @@ import 'package:flutter_whisper_kit_example/main.dart';
 class MockFlutterWhisperKit extends FlutterWhisperKit {
   bool modelLoaded = false;
   String? loadedModelVariant;
-  final StreamController<Progress> _modelProgressController = StreamController<Progress>.broadcast();
-  final StreamController<TranscriptionResult> _transcriptionController = StreamController<TranscriptionResult>.broadcast();
-  
+  final StreamController<Progress> _modelProgressController =
+      StreamController<Progress>.broadcast();
+  final StreamController<TranscriptionResult> _transcriptionController =
+      StreamController<TranscriptionResult>.broadcast();
+
   @override
   Future<String?> loadModel(
     String? variant, {
@@ -18,7 +20,7 @@ class MockFlutterWhisperKit extends FlutterWhisperKit {
   }) async {
     loadedModelVariant = variant;
     modelLoaded = true;
-    
+
     // Simulate progress updates
     final progress50 = const Progress(
       totalUnitCount: 100,
@@ -26,29 +28,29 @@ class MockFlutterWhisperKit extends FlutterWhisperKit {
       fractionCompleted: 0.5,
       isIndeterminate: false,
     );
-    
+
     _modelProgressController.add(progress50);
     if (onProgress != null) {
       onProgress(progress50);
     }
-    
+
     await Future.delayed(const Duration(milliseconds: 100));
-    
+
     final progress100 = const Progress(
       totalUnitCount: 100,
       completedUnitCount: 100,
       fractionCompleted: 1.0,
       isIndeterminate: false,
     );
-    
+
     _modelProgressController.add(progress100);
     if (onProgress != null) {
       onProgress(progress100);
     }
-    
+
     return 'Model loaded: $variant';
   }
-  
+
   @override
   Future<TranscriptionResult?> transcribeFromFile(
     String filePath, {
@@ -57,7 +59,7 @@ class MockFlutterWhisperKit extends FlutterWhisperKit {
     if (!modelLoaded) {
       throw Exception('Model not loaded');
     }
-    
+
     return TranscriptionResult(
       text: 'This is a mock transcription result',
       segments: [
@@ -75,12 +77,10 @@ class MockFlutterWhisperKit extends FlutterWhisperKit {
         ),
       ],
       language: options.language ?? 'en',
-      timings: const TranscriptionTimings(
-        fullPipeline: 1.0,
-      ),
+      timings: const TranscriptionTimings(fullPipeline: 1.0),
     );
   }
-  
+
   @override
   Future<String?> startRecording({
     DecodingOptions options = const DecodingOptions(),
@@ -89,7 +89,7 @@ class MockFlutterWhisperKit extends FlutterWhisperKit {
     if (!modelLoaded) {
       throw Exception('Model not loaded');
     }
-    
+
     // Simulate transcription stream
     _transcriptionController.add(
       TranscriptionResult(
@@ -109,26 +109,25 @@ class MockFlutterWhisperKit extends FlutterWhisperKit {
           ),
         ],
         language: options.language ?? 'en',
-        timings: const TranscriptionTimings(
-          fullPipeline: 1.0,
-        ),
+        timings: const TranscriptionTimings(fullPipeline: 1.0),
       ),
     );
-    
+
     return 'Recording started';
   }
-  
+
   @override
   Future<String?> stopRecording({bool loop = false}) async {
     return 'Recording stopped';
   }
-  
+
   @override
   Stream<Progress> get modelProgressStream => _modelProgressController.stream;
-  
+
   @override
-  Stream<TranscriptionResult> get transcriptionStream => _transcriptionController.stream;
-  
+  Stream<TranscriptionResult> get transcriptionStream =>
+      _transcriptionController.stream;
+
   void dispose() {
     _modelProgressController.close();
     _transcriptionController.close();
@@ -137,9 +136,7 @@ class MockFlutterWhisperKit extends FlutterWhisperKit {
 
 // Helper function to build test widget
 Widget buildTestApp() {
-  return const MaterialApp(
-    home: MyApp(),
-  );
+  return const MaterialApp(home: MyApp());
 }
 
 // Custom ModelLoadingIndicator for testing that accepts Future<String?>

--- a/packages/flutter_whisper_kit/example/test/widget_test.dart
+++ b/packages/flutter_whisper_kit/example/test/widget_test.dart
@@ -16,17 +16,14 @@ void main() {
     await tester.pumpWidget(buildTestApp());
 
     // Verify that app title is displayed
-    expect(
-      find.text('Flutter WhisperKit Example'),
-      findsOneWidget,
-    );
-    
+    expect(find.text('Flutter WhisperKit Example'), findsOneWidget);
+
     // Verify that buttons are present instead of looking for dropdowns
     expect(find.byType(ElevatedButton), findsWidgets);
-    
+
     // Verify that file transcription section is present
     expect(find.text('File Transcription'), findsOneWidget);
-    
+
     // Verify that real-time transcription section is present
     expect(find.text('Real-time Transcription'), findsOneWidget);
   });

--- a/packages/flutter_whisper_kit/lib/src/models/transcription_result.dart
+++ b/packages/flutter_whisper_kit/lib/src/models/transcription_result.dart
@@ -513,13 +513,14 @@ class TranscriptionResult {
                   Map<String, dynamic>.from(e as Map),
                 ),
               )
-              .toList() ?? [],
+              .toList() ??
+          [],
       language: json['language'] as String? ?? 'en',
       timings:
           json['timings'] != null
               ? TranscriptionTimings.fromJson(
-                  Map<String, dynamic>.from(json['timings'] as Map),
-                )
+                Map<String, dynamic>.from(json['timings'] as Map),
+              )
               : const TranscriptionTimings(),
       seekTime:
           json['seekTime'] != null

--- a/packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart
+++ b/packages/flutter_whisper_kit/lib/src/platform_specifics/whisper_kit_message.g.dart
@@ -15,7 +15,6 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -41,23 +40,34 @@ class WhisperKitMessage {
   /// Constructor for [WhisperKitMessage].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  WhisperKitMessage({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  WhisperKitMessage({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix =
+           messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<String?> loadModel(String? variant, String? modelRepo, bool redownload) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.loadModel$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+  Future<String?> loadModel(
+    String? variant,
+    String? modelRepo,
+    bool redownload,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.loadModel$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[variant, modelRepo, redownload],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[variant, modelRepo, redownload]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -73,14 +83,21 @@ class WhisperKitMessage {
     }
   }
 
-  Future<String?> transcribeFromFile(String filePath, Map<String, Object?> options) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.transcribeFromFile$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+  Future<String?> transcribeFromFile(
+    String filePath,
+    Map<String, Object?> options,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.transcribeFromFile$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[filePath, options],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[filePath, options]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -96,14 +113,21 @@ class WhisperKitMessage {
     }
   }
 
-  Future<String?> startRecording(Map<String, Object?> options, bool loop) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.startRecording$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+  Future<String?> startRecording(
+    Map<String, Object?> options,
+    bool loop,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.startRecording$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[options, loop],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[options, loop]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -120,13 +144,17 @@ class WhisperKitMessage {
   }
 
   Future<String?> stopRecording(bool loop) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.stopRecording$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.flutter_whisper_kit.WhisperKitMessage.stopRecording$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[loop],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[loop]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/packages/flutter_whisper_kit/pubspec.yaml
+++ b/packages/flutter_whisper_kit/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_whisper_kit
 description: "A Flutter plugin for on-device speech recognition and transcription using WhisperKit."
 version: 0.0.1
-homepage: https://github.com/r0227n/flutter_whisper_kit/tree/main/flutter_whisper_kit
-repository: https://github.com/r0227n/flutter_whisper_kit/tree/main/packages/flutter_whisper_kit
+homepage: https://github.com/r0227n/flutter_whisper_kit/tree/develop/packages/flutter_whisper_kit
+repository: https://github.com/r0227n/flutter_whisper_kit/tree/develop/packages/flutter_whisper_kit
 issue_tracker: https://github.com/r0227n/flutter_whisper_kit/issues
 
 environment:

--- a/packages/flutter_whisper_kit_apple/pubspec.yaml
+++ b/packages/flutter_whisper_kit_apple/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_whisper_kit_apple
 description: "iOS and macOS implementation of the flutter_whisper_kit plugin, providing on-device speech recognition and transcription capabilities using WhisperKit."
 version: 0.0.1
-homepage: https://github.com/r0227n/flutter_whisper_kit/tree/main/flutter_whisper_kit_apple
-repository: https://github.com/r0227n/flutter_whisper_kit/tree/main/packages/flutter_whisper_kit_apple
+homepage: https://github.com/r0227n/flutter_whisper_kit/tree/develop/packages/flutter_whisper_kit_apple
+repository: https://github.com/r0227n/flutter_whisper_kit/tree/develop/packages/flutter_whisper_kit_apple
 issue_tracker: https://github.com/r0227n/flutter_whisper_kit/issues
 
 environment:


### PR DESCRIPTION
<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->

## Related Issue
<!-- Please specify the Issue that this PR will close -->
Close #xxx

## Description
- repositoryのURL修正
- flutter_whisper_kit で　`dart format .`を実行

<!-- このPRで行った変更内容を詳細に記載してください -->
This pull request focuses on improving code readability and consistency across multiple test files in the `flutter_whisper_kit` package. The changes primarily involve formatting adjustments, such as breaking long lines into multiple lines and ensuring consistent indentation, with no functional impact on the tests.

### Code readability improvements:

* **General formatting updates across test files**: Updated widget initialization to use consistent multi-line formatting for better readability. For example, `MaterialApp` widget declarations now follow a consistent style across all test files, including `app_integration_test.dart` [[1]](diffhunk://#diff-5965ddcf8305fa4ac730054584bc0d18d1a25d9f940955c9c274061e5061ac37L8-R8) `file_transcription_test.dart` [[2]](diffhunk://#diff-98098e3fede2c51b238806d2099e656270f93adfd58cf3e326f2cf871079e81dL10-R14) and others. 
* **Improved parameter formatting in assertions**: Adjusted the formatting of `expect` statements to align parameters vertically, enhancing clarity in files like `app_integration_test.dart` [[1]](diffhunk://#diff-5965ddcf8305fa4ac730054584bc0d18d1a25d9f940955c9c274061e5061ac37L33-R34) and `file_transcription_test.dart` [[2]](diffhunk://#diff-98098e3fede2c51b238806d2099e656270f93adfd58cf3e326f2cf871079e81dL21-R47).

### Mock utility updates:

* **StreamController formatting in `mocks.dart`**: Reformatted the initialization of `StreamController` instances to improve line breaks and indentation in `test_utils/mocks.dart` [[1]](diffhunk://#diff-744dbc5f7373233055c4594956aa5bba340973bb1e4c9cfa3891db2e0ff3b7bcL9-R12) [[2]](diffhunk://#diff-744dbc5f7373233055c4594956aa5bba340973bb1e4c9cfa3891db2e0ff3b7bcL130-R129).

### Minor adjustments:

* **List formatting in `transcription_result.dart`**: Reformatted the `.toList()` call in the `TranscriptionResult` model to improve line readability.
## Checklist

- [ ]  xxx